### PR TITLE
Pe develop istio datadog setup

### DIFF
--- a/common/istio/istio-install/base/kustomization.yaml
+++ b/common/istio/istio-install/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 
 patches:
 - path: patches/service.yaml
+- path: patches/istiod-service.yaml
 - path: patches/istio-configmap-disable-tracing.yaml
 - path: patches/disable-debugging.yaml
 - path: patches/istio-ingressgateway-remove-pdb.yaml

--- a/common/istio/istio-install/base/patches/istiod-service.yaml
+++ b/common/istio/istio-install/base/patches/istiod-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: istiod
+  namespace: istio-system
+  annotations:
+    ad.datadoghq.com/service.check_names: '["istio"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: '[{"istiod_endpoint": "http://%%host%%:15014/metrics", "use_openmetrics": true}]'

--- a/common/istio/istio-install/base/patches/service.yaml
+++ b/common/istio/istio-install/base/patches/service.yaml
@@ -9,3 +9,8 @@ metadata:
     ad.datadoghq.com/service.instances: '[{"istio_mesh_endpoint": "http://%%host%%:15020/stats/prometheus", "use_openmetrics": true}]'
 spec:
   type: ClusterIP
+  ports:
+    - name: http-monitoring
+      port: 15020
+      protocol: TCP
+      targetPort: 15020

--- a/common/istio/istio-install/base/patches/service.yaml
+++ b/common/istio/istio-install/base/patches/service.yaml
@@ -3,5 +3,9 @@ kind: Service
 metadata:
   name: istio-ingressgateway
   namespace: istio-system
+  annotations:
+    ad.datadoghq.com/service.check_names: '["istio"]'
+    ad.datadoghq.com/service.init_configs: '[{}]'
+    ad.datadoghq.com/service.instances: '[{"istio_mesh_endpoint": "http://%%host%%:15020/stats/prometheus", "use_openmetrics": true}]'
 spec:
   type: ClusterIP


### PR DESCRIPTION
This pull request adds Datadog monitoring support for Istio components by introducing new service annotations and exposing monitoring ports. The changes ensure that both `istiod` and `istio-ingressgateway` services are configured for metrics collection via Datadog.

**Datadog monitoring integration:**

* Added Datadog annotations to the `istiod` service by introducing a new patch file `patches/istiod-service.yaml`, enabling metrics collection at the endpoint `http://%%host%%:15014/metrics`. (`common/istio/istio-install/base/patches/istiod-service.yaml`)
* Updated the kustomization to include the new `istiod-service.yaml` patch for deployment. (`common/istio/istio-install/base/kustomization.yaml`)
* Added Datadog annotations to the `istio-ingressgateway` service for mesh metrics at `http://%%host%%:15020/stats/prometheus`. (`common/istio/istio-install/base/patches/service.yaml`)

**Service configuration updates:**

* Exposed a new `http-monitoring` port (15020) on the `istio-ingressgateway` service to allow Datadog to scrape metrics. (`common/istio/istio-install/base/patches/service.yaml`)